### PR TITLE
Fix: cast expires_in to int before addSeconds

### DIFF
--- a/src/Vipps.php
+++ b/src/Vipps.php
@@ -40,7 +40,8 @@ class Vipps
         $body = $response->getBody();
         $data = json_decode($body, true); // true to get associative array
 
-        $expiresAt = $now->addSeconds($data['expires_in']);
+        $expiresIn = (int) ($data['expires_in'] ?? 0);
+        $expiresAt = $now->addSeconds($expiresIn);
 
         VippsToken::create([
             'token' => $data['access_token'],


### PR DESCRIPTION
Problem: Carbon::addSeconds expects int|float but Vipps API may return expires_in as a string.\n\nFix: Cast expires_in to int before calling addSeconds.\n\nWhy: Prevents type error across PHP/Carbon versions and is harmless when value is already an integer.\n\nTested: Ran Pint; integration validated downstream by persisting correct expires_at in DB (SQLite dev / Postgres prod).

Thanks for creating this package, Knut!